### PR TITLE
Fixed bug in json plugin that occurs when inline json option is true.

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -51,7 +51,7 @@ define(['text'], function(text){
         write : function(pluginName, moduleName, write){
             if(moduleName in buildMap){
                 var content = buildMap[moduleName];
-                write('define("'+ pluginName +'!'+ moduleName +'", function(){ return '+ content +';});\n');
+                write('define("'+ pluginName +'!'+ moduleName +'", function(){ return "'+ content +'";});\n');
             }
         }
 


### PR DESCRIPTION
Need to write out the content as a string in the opitmized module so
that the JSON.parse call that is made during runtime will succeed.
