### PR TITLE
fixes #16 and adds optional header object to the text.get call

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -37,7 +37,7 @@ define(['text'], function(text){
                     }
                 },
                     onLoad.error, {
-                        accepts: 'application/json'
+                        accept: 'application/json'
                     }
                 );
             }


### PR DESCRIPTION
the api of the text plugin change has been merged in requirejs/text so now json! can also use it and set the `accepts` headers correctly before doing the xhr request.
