### PR TITLE
Added an `onerror` handle in the image plugin.

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -25,9 +25,9 @@ define(function(){
                 onLoad(null); //avoid errors on the optimizer since it can't inline image files
             }else{
                 img = new Image();
-		img.onerror = function (err) {
-		    onLoad.error(err);
-		};
+                img.onerror = function (err) {
+                    onLoad.error(err);
+                };
                 img.onload = function(evt){
                     onLoad(img);
                     try {


### PR DESCRIPTION
Added an `onerror` handle in the image plugin. When an image couldn't be loaded (i.e. 404 error), this caused a timeout and in turn, caused a failure to invoke subsequent errbacks from require.js' side (a behaviour I'm still investigating).
