### PR TITLE
bug fix - text.js not in "main" filed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "requirejs-plugins",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": [
     "src/async.js",
     "src/depend.js",


### PR DESCRIPTION
I have recently stopped using exportsOverrides for Bower.
When I did this I noticed the `text.js` file was not getting loaded correctly by the json plugin.

I've added `text.js` to the `bower.json` main files and updated bower.json to version 1.0.2
After merging please tag the release.

Thanks
