### PR TITLE
Make loading add ".json" if missing from path

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -24,6 +24,10 @@ define(['text'], function(text){
     return {
 
         load : function(name, req, onLoad, config) {
+            // Make sure file part of url ends with .json, add it if not
+            name = name.replace(new RegExp("^[^?]*"),function(base){
+                return base.substr(-5) === ".json" ? base : base+".json";
+            });
             if ( config.isBuild && (config.inlineJSON === false || name.indexOf(CACHE_BUST_QUERY_PARAM +'=') !== -1) ) {
                 //avoid inlining cache busted JSON or if inlineJSON:false
                 onLoad(null);


### PR DESCRIPTION
Forcing the user to include ".json" in the path seems to clash with the API of other plugins that are designed to load a specific type of file (coffee-script, jade, etc). These plugins expects the user to enter the filename without the filetype ending.

This commit makes the JSON plugin adhere to that convention by adding ".json" to the path, but to make sure existing usage won't break it first checks if it isn't already there.

This will however break for people who try to load JSON from files ending in something other than .json, but they should learn better anyway, right? :) 

The text plugin upon which this plugin is modelled is different as there are a multitude of file types which could conceivably be loaded as text (html, htm, txt, etc).
