### PR TITLE
correctly normalize json path

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -44,8 +44,12 @@ define(['text'], function(text){
         },
 
         normalize : function (name, normalize) {
-            //used normalize to avoid caching references to a "cache busted" request
-            return (name.indexOf(CACHE_BUST_FLAG) === -1)? name : cacheBust(name);
+            // used normalize to avoid caching references to a "cache busted" request
+            if (name.indexOf(CACHE_BUST_FLAG) !== -1) {
+                name = cacheBust(name);
+            }
+            // resolve any relative paths
+            return normalize(name);
         },
 
         //write method based on RequireJS official text plugin by James Burke


### PR DESCRIPTION
in the case where you make a relative require w/ a `..` in the path:

``` js
require([
    'json!./../string-bundle.json'
], function(strings) {
    // ...
});
```

the plugin's `normalize` function needs to call the supplied `normalize` parameter (i.e. [the second argument](http://requirejs.org/docs/plugins.html#apinormalize) to the plugin's `normalize` function) in order to correctly resolve the `..`.
