### PR TITLE
Using req.toUrl instead of name when injecting a script.

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -37,7 +37,7 @@ define(function(){
                 //create a global variable that stores onLoad so callback
                 //function can define new module after async load
                 window[id] = onLoad;
-                injectScript(formatUrl(name, id));
+                injectScript(formatUrl(req.toUrl(name), id));
             }
         }
     };


### PR DESCRIPTION
using req.toUrl(name) instead of just name so that the url for the script alias name is resolved appropriately.
