### PR TITLE
Avoid loading empty: urls

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -27,6 +27,9 @@ define(['text'], function(text){
             if ( config.isBuild && (config.inlineJSON === false || name.indexOf(CACHE_BUST_QUERY_PARAM +'=') !== -1) ) {
                 //avoid inlining cache busted JSON or if inlineJSON:false
                 onLoad(null);
+            } else if ( req.toUrl(name) === 'empty:' ) {
+                //avoid loading empty: urls
+                onLoad(null);
             } else {
                 text.get(req.toUrl(name), function(data){
                     if (config.isBuild) {


### PR DESCRIPTION
r.js let's you define certain paths as "empty:" so they are skipped during optimization.

There's a piece of code in text.js that skips modules (see https://github.com/requirejs/text/blob/master/text.js). This patch applies the same trick to json.js.
