### PR TITLE
Call onload.error if JSON parsing fails.

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -30,11 +30,17 @@ define(['text'], function(text){
                 onLoad(null);
             } else {
                 text.get(req.toUrl(name), function(data){
+                    var parsed;
                     if (config.isBuild) {
                         buildMap[name] = data;
                         onLoad(data);
                     } else {
-                        onLoad(jsonParse(data));
+                        try {
+                            parsed = jsonParse(data);
+                        } catch (e) {
+                            onLoad.error(e);
+                        }
+                        onLoad(parsed);
                     }
                 },
                     onLoad.error, {


### PR DESCRIPTION
When JSON parsing fails, neither require's `onLoad` or `onLoad.error` method is called. This makes it impossible to handle errors due to malformed JSON. This updates the JSON plugin to call `onLoad.error` when JSON parsing fails.