### PR TITLE
issue71: Fix for issue #71 ReferenceError: Can't find variable: WebFont

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -34,7 +34,7 @@ define(['propertyParser'], function (propertyParser) {
                 data.inactive = function(){
                     onLoad(false);
                 };
-                req([(document.location.protocol === 'https:'? 'https' : 'http') +'://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js'], function(){
+                req([(document.location.protocol === 'https:'? 'https' : 'http') +'://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js'], function(WebFont){
                     WebFont.load(data);
                 });
             }


### PR DESCRIPTION
Fix for the "ReferenceError: Can't find variable: WebFont" exception
as proposed by chris-tomich at https://github.com/millermedeiros/requirejs-plugins/issues/71

I was affected by the same issue, and this simple fix solved it.