### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,5 +1,7 @@
 # RequireJS plugins
 
+[![CDNJS](https://img.shields.io/cdnjs/v/requirejs-plugins.svg)](https://cdnjs.com/libraries/requirejs-plugins)
+
 Small set of plugins for [RequireJS](http://requirejs.org). Some plugins may
 also work on other AMD loaders (never tested it).
 


### PR DESCRIPTION
This will add the badge to show its version on CDNJS and also link to its page on CDNJS!