### PR TITLE
goog plugin upgrade for fix breaking changes

### DIFF
--- a/src/goog.js
+++ b/src/goog.js
@@ -4,17 +4,16 @@
  * Version: 0.2.0 (2011/12/06)
  * Released under the MIT license
  */
-define(['async', 'propertyParser'], function (async, propertyParser) {
+define(['propertyParser'], function (propertyParser) {
 
     var rParts = /^([^,]+)(?:,([^,]+))?(?:,(.+))?/;
 
     function parseName(name){
         var match = rParts.exec(name),
             data = {
-                moduleName : match[1],
-                version : match[2] || '1'
+                version : match[1] || '1'
             };
-        data.settings = propertyParser.parseProperties(match[3]);
+        data.settings = propertyParser.parseProperties(match[2]);
         return data;
     }
 
@@ -28,8 +27,8 @@ define(['async', 'propertyParser'], function (async, propertyParser) {
 
                 settings.callback = onLoad;
 
-                req(['async!'+ (document.location.protocol === 'https:'? 'https' : 'http') +'://www.google.com/jsapi'], function(){
-                    google.load(data.moduleName, data.version, settings);
+                req([(document.location.protocol === 'https:'? 'https' : 'http') +'://www.gstatic.com/charts/loader.js'], function(){
+                    google.charts.load(data.version, settings);
                 });
             }
         }


### PR DESCRIPTION
goog plugin upgrade for fix breaking changes in google charts loading  using gstatic library like docu in https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code

Check my console error before and web app before and after fix:
![Captura de pantalla de 2020-07-03 11-00-41](https://user-images.githubusercontent.com/1810927/86620715-6cc93200-bf82-11ea-8b7b-f447351f4b47.png)
![Captura de pantalla de 2020-07-06 12-14-10](https://user-images.githubusercontent.com/1810927/86620722-6fc42280-bf82-11ea-9512-34bbf3418cf7.png)

